### PR TITLE
Add quickupload bundle to cmsui's theme

### DIFF
--- a/plone/app/deco/profiles/default/registry.xml
+++ b/plone/app/deco/profiles/default/registry.xml
@@ -1046,6 +1046,7 @@
                 <element>jquerytools</element>
                 <element>tinymce</element>
                 <element>deco</element>
+                <element>quickupload</element>
             </element>
             <element key="deco">
                 <element>jquerytools</element>


### PR DESCRIPTION
Deco redefines cmsui's theme so it can add the deco bundle, which is slightly annoying.
